### PR TITLE
16 setup rds

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -30,7 +30,7 @@ jobs:
    # Terraform variables here. (define in variables.tf)
    # use format: TF_VAR_<variable name in variables.tf>: ${{ secrets.<github secrets variable name> }}
    # e.g. TF_VAR_aws_access_key_id:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-    TF_VAR_db_password: ${{ secrets.db_password }}
+    TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
    defaults:
      run:
        shell: bash

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -26,10 +26,11 @@ jobs:
    name: "Terraform Infrastructure Change Management"
    permissions: write-all
    runs-on: ubuntu-latest
-   # env:  UNCOMMENT THIS TO ADD TERRAFORM VARIABLES
+   env:  # ADD TERRAFORM VARIABLES
    # Terraform variables here. (define in variables.tf)
-   # use format: TF_VAR_<variable name in variables.tf>: ${{ secrets.<github secrets variable name}}
+   # use format: TF_VAR_<variable name in variables.tf>: ${{ secrets.<github secrets variable name> }}
    # e.g. TF_VAR_aws_access_key_id:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+    TF_VAR_db_password: ${{ secrets.db_password }}
    defaults:
      run:
        shell: bash

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,3 +15,32 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+resource "aws_security_group" "allow_5432" {
+  name        = "c18-climate-monitor-rds-sg"
+  description = "Allows all traffic on port 5432."
+  vpc_id      = "vpc-0adcb6a62ca552c01" # c18-VPC
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_ingress_5432" {
+  security_group_id = aws_security_group.allow_5432.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 5432
+  ip_protocol       = "tcp"
+  to_port           = 5432
+}
+
+resource "aws_db_instance" "climate" {
+  allocated_storage    = 100
+  db_name = "postgres"
+  identifier             = "c18-climate-monitor-rds"
+  engine               = "postgres"
+  engine_version       = "17.5"
+  instance_class       = "db.t3.micro"
+  username             = "climate"
+  password             = var.db_password
+  skip_final_snapshot  = true
+  publicly_accessible = true
+  vpc_security_group_ids = [aws_security_group.allow_5432.id]
+  db_subnet_group_name = "c18-public-subnet-group"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "rds_public_address" {
+    value = aws_db_instance.climate.address
+    description = "Public address/host of the RDS instance"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,3 @@
+variable "db_password" {
+    type = string
+}


### PR DESCRIPTION
closes: #16 
- Ami: as repository owner you need to add a repository secret called 'db_password'
- Terraform code to provision a publicly accessible RDS with a security group allowing inbound traffic on 5432