### PR TITLE
Change environment variable names of lambdas to match python code.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -416,11 +416,11 @@ resource "aws_lambda_function" "location_assignment" {
 
   environment {
     variables = {
-      DB_HOST     = aws_db_instance.climate.address
-      DB_PORT     = 5432
-      DB_USER     = "climate"
-      DB_PASSWORD = var.db_password
-      DB_NAME     = "postgres"
+      HOST     = aws_db_instance.climate.address
+      PORT     = 5432
+      USER     = "climate"
+      DBPASSWORD = var.db_password
+      DBNAME     = "postgres"
     }
   }
 
@@ -457,11 +457,11 @@ resource "aws_lambda_function" "future_climate" {
 
   environment {
     variables = {
-      DB_HOST     = aws_db_instance.climate.address
-      DB_PORT     = 5432
-      DB_USER     = "climate"
-      DB_PASSWORD = var.db_password
-      DB_NAME     = "postgres"
+      HOST     = aws_db_instance.climate.address
+      PORT     = 5432
+      USER     = "climate"
+      DBPASSWORD = var.db_password
+      DBNAME     = "postgres"
     }
   }
 


### PR DESCRIPTION
Change the environment variable names to match those in the python code for the `location_assignment` and `future_climate` lambdas in terraform.